### PR TITLE
Remove DateTime package dependency since based on the source codes, i…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.md') as history_file:
 
 requirements = [ 
     "pandas", "cryptography", "pillow", "scikit-image", "matplotlib", "statsmodels",
-    "scipy", "datetime" 
+    "scipy"
     ]
 
 test_requirements = ['pytest>=3', ]


### PR DESCRIPTION
…t looks like python's own datetime from the standard libary is sufficient.

Please reference issue #5 for the case justification.

